### PR TITLE
Add additional getIntent check

### DIFF
--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -215,7 +215,7 @@ public class AuthorizationManagementActivity extends Activity {
          * or the user cancels the authorization flow.
          */
 
-        if (blockOnResume) {
+        if (blockOnResume && getIntent().getData() == null) {
             return;
         } else {
             blockOnResume = true;


### PR DESCRIPTION
Add an additional getIntent check to avoid blocking onResume if a user gets an instant redirect because he is already logged in.